### PR TITLE
Fix txUtils invalid `.length` on function

### DIFF
--- a/src/txHelper.ts
+++ b/src/txHelper.ts
@@ -62,7 +62,7 @@ const addCommand = (transaction, commandName, params) => {
   const payload = getOrCreatePayload(transaction)
   const reducedPayload = getOrCreateReducedPayload(payload)
 
-  reducedPayload.addCommands(command, reducedPayload.getCommandsList.length)
+  reducedPayload.addCommands(command, reducedPayload.getCommandsList().length)
   payload.setReducedPayload(reducedPayload)
 
   const txWithCommand = cloneDeep(transaction)


### PR DESCRIPTION
The property `getCommandsList` is a function that returns an `Array`. The `.length` was probably intended for the result of calling the function not the function itself.  Calling `.length` on a function returns the number of arguments in the function signature which is probably not what the author intended to use for  `addCommands`.