### PR TITLE
Adjusting Buffer use in sign method

### DIFF
--- a/src/txHelper.ts
+++ b/src/txHelper.ts
@@ -110,7 +110,7 @@ const hash = transaction => {
  * @param {String} privateKeyHex - private key of query's creator in hex.
  */
 const sign = (transaction, privateKeyHex) => {
-  const privateKey = Buffer.from(privateKeyHex, 'hex')
+  const privateKey = BF.from(privateKeyHex, 'hex')
   const publicKey = derivePublicKey(privateKey)
 
   const payloadHash = hash(transaction)


### PR DESCRIPTION
In the current version of master the use of Buffer it's wrong using **Buffer** instead of the alias **BF**